### PR TITLE
feat: Remove fullscreen button, add settings, and display logos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "babel-loader": "^9.1.3",
         "electron": "^37.2.3",
         "electron-builder": "^26.0.12",
-        "webpack": "^5.100.2",
+        "webpack": "^5.101.0",
         "webpack-cli": "^6.0.1"
       }
     },
@@ -6580,9 +6580,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
+      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-loader": "^9.1.3",
     "electron": "^37.2.3",
     "electron-builder": "^26.0.12",
-    "webpack": "^5.100.2",
+    "webpack": "^5.101.0",
     "webpack-cli": "^6.0.1"
   },
   "build": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,10 +9,14 @@ const App = () => {
         setConfig(newConfig);
     };
 
+    const handleSettingsClick = () => {
+        setConfig(null);
+    };
+
     return (
         <div>
             {config ? (
-                <Display config={config} />
+                <Display config={config} onSettingsClick={handleSettingsClick} />
             ) : (
                 <Config onSave={handleConfigSave} />
             )}

--- a/src/components/Config.js
+++ b/src/components/Config.js
@@ -11,6 +11,7 @@ const Config = ({ onSave }) => {
     const [totalPeriods, setTotalPeriods] = useState(2);
     const [showPeriod, setShowPeriod] = useState(true);
     const [showTimer, setShowTimer] = useState(true);
+    const [timeFormat, setTimeFormat] = useState('minutes');
 
     const handleSave = () => {
         onSave({
@@ -24,6 +25,7 @@ const Config = ({ onSave }) => {
             totalPeriods,
             showPeriod,
             showTimer,
+            timeFormat,
         });
     };
 
@@ -74,6 +76,13 @@ const Config = ({ onSave }) => {
                         <option value="4">4</option>
                     </select>
                 </div>
+                <div className="input-group">
+                    <label htmlFor="time-format">Formato del Tiempo:</label>
+                    <select id="time-format" value={timeFormat} onChange={(e) => setTimeFormat(e.target.value)}>
+                        <option value="minutes">Minutos y Segundos</option>
+                        <option value="seconds">Solo Segundos</option>
+                    </select>
+                </div>
             </div>
 
             <div className="config-section">
@@ -85,6 +94,15 @@ const Config = ({ onSave }) => {
                 <div className="input-group">
                     <label htmlFor="show-timer">Mostrar Temporizador:</label>
                     <input type="checkbox" id="show-timer" checked={showTimer} onChange={(e) => setShowTimer(e.target.checked)} />
+                </div>
+            </div>
+
+            <div className="config-section">
+                <h2>Logos Disponibles</h2>
+                <div className="logo-gallery">
+                    <img src="logo/camuvi.png" alt="Camuvi" width="50" />
+                    <img src="logo/huachipato.png" alt="Huachipato" width="50" />
+                    <img src="logo/nuevo-pacifico.png" alt="Nuevo Pacifico" width="50" />
                 </div>
             </div>
 

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 
-const Display = ({ config }) => {
+const Display = ({ config, onSettingsClick }) => {
     const [homeScore, setHomeScore] = useState(0);
     const [awayScore, setAwayScore] = useState(0);
     const [homeFouls, setHomeFouls] = useState(0);
@@ -33,6 +33,9 @@ const Display = ({ config }) => {
     }, [isRunning, time]);
 
     const formatTime = (seconds) => {
+        if (config.timeFormat === 'seconds') {
+            return seconds;
+        }
         const minutes = Math.floor(seconds / 60);
         const secs = seconds % 60;
         return `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
@@ -56,10 +59,6 @@ const Display = ({ config }) => {
             setPeriod(period + 1);
             handleReset();
         }
-    };
-
-    const enterFullscreen = () => {
-        document.documentElement.requestFullscreen();
     };
 
     const homeLogoURL = config.homeLogo ? URL.createObjectURL(config.homeLogo) : null;
@@ -120,7 +119,7 @@ const Display = ({ config }) => {
                 </div>
             </div>
             <div id="controls-container" className="controls-container">
-                <button id="enter-fullscreen" className="btn-fullscreen fullscreen-hidden" onClick={enterFullscreen}>Pantalla Completa</button>
+                <button id="settings-button" className="btn-settings" onClick={onSettingsClick}>Configuración</button>
             </div>
         </div>
     );


### PR DESCRIPTION
This commit introduces several changes to the application:

- Removes the fullscreen button from the display.
- Adds a "Settings" button to the display, allowing users to return to the configuration screen.
- Adds a time format setting to the configuration screen, allowing users to choose between "minutes and seconds" and "only seconds".
- Adds a gallery of available logos to the configuration screen.